### PR TITLE
[DRAFT] Add correlation identifier to match commands and responses

### DIFF
--- a/cmd.proto
+++ b/cmd.proto
@@ -7,6 +7,7 @@ option go_package = "./wire";
 message Command {
     string cmd = 1;
     repeated string args = 2;
+    string corr_id = 3;
 }
 
 message Response {
@@ -21,4 +22,5 @@ message Response {
     google.protobuf.Struct attrs = 7;
     repeated google.protobuf.Value v_list = 8;
     map<string, string> v_ss_map = 9;
+    string corr_id = 10;
 }


### PR DESCRIPTION
Fixes https://github.com/DiceDB/dice/issues/1591

The source of the issue is absence of synchronization when Client is writing to and reading from TCP connection.

Need your feedback, to make sure you are ok with the approach I took:
- Use fixed 4 byte header for each message (`wire.Command`/`wire.Response`)
- Add correlation_id to each command/response to match them
- On `Client` side, read responses from `net.Conn` in a loop
- Put responses in corresponding channel (map[corr_id] = chan *Response)
- Each `Client.Fire()` reads from a corresponding channel

Here are the links to all of the PRs (this fix requires changes to multiple repositories):
[dicedb-go PR](https://github.com/DiceDB/dicedb-go/pull/4)
[dice PR](https://github.com/DiceDB/dice/pull/1628)
[dicedb-protos PR](https://github.com/DiceDB/dicedb-protos/pull/1)

- [x] Communicate with maintainers on the overall approach
- [ ] Make code production-ready (error handling etc)

Before this change:
![before](https://github.com/user-attachments/assets/1cabf2d9-d1a9-4245-b221-4b961580ca3d)
After this change:
![after](https://github.com/user-attachments/assets/56827420-caab-4c58-88f6-c4598cf50882)
